### PR TITLE
Add create_node.sh script and update README.md for node setup instruc…

### DIFF
--- a/testnet/elysicstestnet-1/README.md
+++ b/testnet/elysicstestnet-1/README.md
@@ -2,41 +2,52 @@
 
 Welcome to the Elys testnet! This guide will help you set up a full node and join the testnet. The producer chain is the Cosmos Hub, and this testnet ensures compatibility and stability for the Interchain Security (ICS) environment.
 
----
+## Quick Reference
+- Consumer ID: 113
+- Chain ID: elysicstestnet-1
 
-## Minimum Hardware Requirements
+## Hardware Requirements
 
-To run your node effectively, ensure your machine meets the following requirements:
-
-- **CPU**: 8 cores
-- **RAM**: 16 GB
-- **Disk**: 200 GB SSD
-- **Network**: High-speed internet connection with at least 100 Mbps bandwidth
-
----
+| Component | Minimum Specification |
+|-----------|---------------------|
+| CPU | 8 cores |
+| RAM | 16 GB |
+| Storage | 200 GB SSD |
+| Network | 100 Mbps+ |
 
 ## Software Requirements
 
-- **Operating System**: Linux (Ubuntu 20.04 or later recommended) or macOS
+- **Operating System**: Ubuntu 20.04+ or macOS
 - **Go**: v1.22.6
 
----
+## Validator Setup Instructions
 
-## Instructions to Join the Testnet
-
-#### Opt In [Required only for Validators]
-
-Consumer ID: 113
-Chain ID: elysicstestnet-1
-
-```
-gaiad tx provider opt-in 113 --from [YOUR_KEY] --chain-id provider --fees 2000uatom --node https://rpc.provider-sentry-01.ics-testnet.polypore.xyz:443
+### 1. Opt-In to Consumer Chain (Validators Only)
+```bash
+gaiad tx provider opt-in 113 \
+    --from [YOUR_KEY] \
+    --chain-id provider \
+    --fees 2000uatom \
+    --node https://rpc.provider-sentry-01.ics-testnet.polypore.xyz:443
 ```
 
-### 1. Clone the Repository
+### 2. Node Setup Options
 
-Download the consumer chain codebase:
+#### Option A: Quick Setup Script
+```bash
+wget https://raw.githubusercontent.com/elys-network/networks/main/testnet/elysicstestnet-1/create_node.sh
+chmod +x create_node.sh
+./create_node.sh "your-moniker-name"
+```
 
+> **⚠️ Important Note for Validators**: 
+> 1. Before running the script, ensure it does not automatically start the node (check and modify the script if needed)
+> 2. After running the script, you must replace the `$HOME/.elys/config/priv_validator_key.json` with your cosmos's provider testnet `priv_validator_key.json` file
+> 3. Only start the node after completing the key replacement to avoid double signing
+
+#### Option B: Manual Setup
+
+1. **Clone and Build**
 ```bash
 git clone https://github.com/elys-network/elys.git
 cd elys
@@ -45,29 +56,38 @@ make install
 elysd init [your-moniker] --chain-id elysicstestnet-1
 ```
 
-### 2. Starting the node:
+2. **Configure Node**
 
-#### a. Fetch the genesis file
-```
+a. Download Genesis File
+```bash
 curl -o $HOME/.elys/config/genesis.json https://raw.githubusercontent.com/elys-network/networks/refs/heads/main/testnet/elysicstestnet-1/genesis.json
 ```
-#### b. [Required only for Validators] Replace `$HOME/.elys/config/priv_validator_key.json` with your cosmos's provider testnet `priv_validator_key.json` Note: You can also use another priv_validator_key.json The instructions for it can be found [here](https://github.com/cosmos/testnets/blob/master/interchain-security/VALIDATOR_JOINING_GUIDE.md#option-two-use-key-delegation).
 
-#### c. Add persistent peers and seeds in config.toml
+b. **For Validators**: Replace Validator Key
+- Replace `$HOME/.elys/config/priv_validator_key.json` with your cosmos's provider testnet key
+- Alternative key delegation instructions available [here](https://github.com/cosmos/testnets/blob/master/interchain-security/VALIDATOR_JOINING_GUIDE.md#option-two-use-key-delegation)
 
-#### d. Set the minimum gas prices in the app.toml file. Recommended 0.001uelys
-You can use USDC ibc token as well once the relayer is set up and denom is known
+c. Configure Node Settings
+- Add persistent peers and seeds in `config.toml`
+- Set minimum gas prices in `app.toml` (recommended: `0.001uelys`)
+  - USDC IBC token can be used once relayer is configured
 
-#### e. Start the node: `elysd start`
+### 3. Running the Node
 
-#### f. Recommended to use systemctl service to run the node:
-
+#### Option A: Direct Start
+```bash
+elysd start
 ```
+
+#### Option B: System Service (Recommended)
+
+1. Create Service File
+```bash
 sudo nano /etc/systemd/system/elysd.service
 ```
-Paste the following:
 
-```
+2. Add Service Configuration
+```ini
 [Unit]
 Description=Elys Network Testnet Node
 After=network.target
@@ -83,11 +103,17 @@ LimitNOFILE=65535
 WantedBy=multi-user.target
 ```
 
-After exiting the editor:
-```
+3. Enable and Manage Service
+```bash
 sudo systemctl daemon-reload
 sudo systemctl enable elysd
-```
 
-To start: `sudo systemctl start elysd`
-To stop : `sudo systemctl stop elysd`
+# Start node
+sudo systemctl start elysd
+
+# Stop node
+sudo systemctl stop elysd
+
+# Check logs
+sudo journalctl -u elysd -f -o cat
+```

--- a/testnet/elysicstestnet-1/create_node.sh
+++ b/testnet/elysicstestnet-1/create_node.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e  # Exit on any error
+
+# Check if MONIKER was provided as argument
+if [ -z "$1" ]; then
+    echo "Error: MONIKER not provided"
+    echo "Usage: $0 <moniker>"
+    echo "Example: $0 my-validator-node"
+    exit 1
+fi
+
+# set variables
+CHAINID="elysicstestnet-1"
+MONIKER="$1"
+DENOM="uelys"
+DBENGINE="pebbledb"
+BLOCKTIME="3s"
+VERSION="v0.54.0"
+
+denali="0f9a0d0b74377b6330053131eb31b8e97d527bee@37.27.81.152:26656"
+utopia="7f4a326cd0e3942203e5479f550657e09356c73c@135.181.86.200:26656"
+nirvana="20407fc4733b0bad9b4f5e74f48a535d210259f8@65.21.116.24:26656"
+euphoria="51bfff7ba2bc8ca1e0f99f6411c9642a00ec5c9c@37.187.154.66:26656"
+shangrila="30eb3ba6b509890df40276c0d0eb418ecae88279@109.135.1.86:26656"
+
+PEERS="$denali,$utopia,$nirvana,$euphoria,$shangrila"
+SEED="$denali"
+
+# Add after variables section
+if [ "$MONIKER" = "YOUR_MONIKER" ]; then
+    echo "Please set your MONIKER before running this script"
+    exit 1
+fi
+
+# stop the node
+sudo systemctl stop elysd.service
+
+# backup the old elys data if any
+if [ -d "$HOME/.elys.bak" ]; then
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    mv "$HOME/.elys.bak" "$HOME/.elys.bak_$TIMESTAMP"
+fi
+mv "$HOME/.elys" "$HOME/.elys.bak"
+
+# download the new binary from releases
+echo "Downloading Elys binary..."
+curl -L https://github.com/elys-network/elys/releases/download/$VERSION/elysd-$VERSION-linux-amd64 -o $HOME/go/bin/elysd || {
+    echo "Failed to download binary"
+    exit 1
+}
+chmod +x $HOME/go/bin/elysd
+
+# download the new binary from sources
+# cd $HOME && git clone https://github.com/elys-network/elys.git && cd $HOME/elys && git fetch && git checkout $VERSION && git pull origin $VERSION && git tag -f $VERSION && make install
+
+# Verify binary exists after download
+if ! command -v elysd &> /dev/null; then
+    echo "elysd binary not found after installation"
+    exit 1
+fi
+
+# init the new node
+elysd init $MONIKER --chain-id $CHAINID
+
+# update config files and fetch genesis
+config_toml="$HOME/.elys/config/config.toml"
+client_toml="$HOME/.elys/config/client.toml"
+app_toml="$HOME/.elys/config/app.toml"
+genesis_json="$HOME/.elys/config/genesis.json"
+
+sed -i -E "s|cors_allowed_origins = \[\]|cors_allowed_origins = [\"\*\"]|g" $config_toml
+sed -i -E "s|db_backend = \".*\"|db_backend = \"$DBENGINE\"|g" $config_toml
+sed -i -E "s|127.0.0.1|0.0.0.0|g" $config_toml
+sed -i -E "s|timeout_commit = \"5s\"|timeout_commit = \"$BLOCKTIME\"|g" $config_toml
+sed -i -E "s|seeds = \".*\"|seeds = \"$SEED\"|g" $config_toml
+sed -i -E "s|persistent_peers = \".*\"|persistent_peers = \"$PEERS\"|g" $config_toml
+
+sed -i -E "s|minimum-gas-prices = \".*\"|minimum-gas-prices = \"0.001$DENOM\"|g" $app_toml
+sed -i -E '/\[api\]/,/^enable = .*$/ s/^enable = .*$/enable = true/' $app_toml
+sed -i -E 's|swagger = .*|swagger = true|g' $app_toml
+sed -i -E "s|localhost|0.0.0.0|g" $app_toml
+sed -i -E 's|unsafe-cors = .*|unsafe-cors = true|g' $app_toml
+sed -i -E "s|app-db-backend = \".*\"|app-db-backend = \"$DBENGINE\"|g" $app_toml
+
+sed -i -E "s|chain-id = \"\"|chain-id = \"$CHAINID\"|g" $client_toml
+sed -i -E "s|keyring-backend = \"os\"|keyring-backend = \"test\"|g" $client_toml
+
+curl https://raw.githubusercontent.com/elys-network/networks/refs/heads/main/testnet/$CHAINID/genesis.json -o $genesis_json
+
+# setup cosmovisor
+mkdir -p $HOME/.elys/cosmovisor/upgrades/$VERSION/bin && cp -a $HOME/go/bin/elysd $HOME/.elys/cosmovisor/upgrades/$VERSION/bin/elysd && rm -rf $HOME/.elys/cosmovisor/current && ln -sf $HOME/.elys/cosmovisor/upgrades/$VERSION $HOME/.elys/cosmovisor/current
+
+# start the node
+sudo systemctl start elysd.service


### PR DESCRIPTION
…tions

- Introduced a new script `create_node.sh` to automate the setup of an Elys testnet node, including downloading binaries, configuring settings, and starting the node.
- Enhanced README.md with a quick reference section, updated hardware requirements, and detailed validator setup instructions, including options for quick and manual setup.
- Added important notes for validators regarding key replacement and node configuration.