### PR TITLE
Update create_node.sh and README.md for Elys testnet configuration

### DIFF
--- a/testnet/elysicstestnet-1/README.md
+++ b/testnet/elysicstestnet-1/README.md
@@ -83,6 +83,45 @@ c. Configure Node Settings
 minimum-gas-prices = "0.0003uelys,0.001ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349,0.001ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
 ```
 
+c. **For Governors**: Run those commands to register as a governor
+
+- Retrieve the governor pubkey:
+
+  ```
+  elysd cometbft show-validator
+  ```
+
+- Create the validator.json file:
+
+```bash
+cat <<EOF > /tmp/validator.json
+{
+	"pubkey": [PUBKEY],
+	"amount": "10000000uelys",
+	"moniker": "[MONIKER]",
+	"identity": "Elys governor",
+	"website": "https://elys.network",
+	"security": "team@elys.network",
+	"details": "validator's (optional) details",
+	"commission-rate": "0.1",
+	"commission-max-rate": "0.2",
+	"commission-max-change-rate": "0.01",
+	"min-self-delegation": "1"
+}
+EOF
+```
+
+- Create the governor:
+
+```bash
+elysd tx staking create-validator \
+    /tmp/validator.json \
+    --from [YOUR_KEY] \
+    --chain-id elysicstestnet-1 \
+    --fees 20000uelys \
+    --gas auto
+```
+
 ### 3. Running the Node
 
 #### Option A: Direct Start

--- a/testnet/elysicstestnet-1/create_node.sh
+++ b/testnet/elysicstestnet-1/create_node.sh
@@ -85,7 +85,7 @@ sed -i -E "s|localhost|0.0.0.0|g" $app_toml
 sed -i -E 's|unsafe-cors = .*|unsafe-cors = true|g' $app_toml
 sed -i -E "s|app-db-backend = \".*\"|app-db-backend = \"$DBENGINE\"|g" $app_toml
 
-sed -i -E "s|chain-id = \"\"|chain-id = \"$CHAINID\"|g" $client_toml
+sed -i -E "s|chain-id = \".*\"|chain-id = \"$CHAINID\"|g" $client_toml
 sed -i -E "s|keyring-backend = \"os\"|keyring-backend = \"test\"|g" $client_toml
 
 curl https://raw.githubusercontent.com/elys-network/networks/refs/heads/main/testnet/$CHAINID/genesis.json -o $genesis_json


### PR DESCRIPTION
- Modified the chain-id assignment in create_node.sh to ensure it correctly replaces any existing value.
- Expanded the README.md with detailed instructions for governors on how to register, including commands to retrieve the governor pubkey and create a validator.json file for validator creation.