### PR TITLE
Enhance mainnet and testnet documentation and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ This repository contains the official chain configurations and setup instruction
 - **Type**: ICS Consumer Chain (Cosmos Hub)
 - [Setup Instructions](testnet/elysicstestnet-1/README.md)
 
+### Mainnet
+
+- **Chain ID**: elys-1
+- **Status**: Active
+- **Type**: ICS Consumer Chain (Cosmos Hub)
+- [Setup Instructions](mainnet/README.md)
+
 ## Repository Structure
 
 ```
@@ -20,12 +27,16 @@ networks/
 │       ├── README.md         # Setup instructions and chain information
 │       ├── create_node.sh    # Automated node setup script
 │       └── genesis.json      # Chain genesis file
+├── mainnet/
+│       ├── README.md         # Setup instructions and chain information
+│       ├── create_node.sh    # Automated node setup script
+│       └── genesis.json      # Chain genesis file
 └── README.md                 # This file
 ```
 
 ## Quick Start
 
-To join the testnet, follow these steps:
+To join one of the networks, follow these steps:
 
 1. Clone this repository:
 

--- a/mainnet/README.md
+++ b/mainnet/README.md
@@ -35,6 +35,22 @@ gaiad tx provider opt-in 21 \
 
 ### 2. Node Setup Options
 
+#### Option A: Quick Setup Script
+
+```bash
+wget https://raw.githubusercontent.com/elys-network/networks/main/mainnet/create_node.sh
+chmod +x create_node.sh
+./create_node.sh "your-moniker-name"
+```
+
+> **⚠️ Important Note for Validators**:
+>
+> 1. Before running the script, ensure it does not automatically start the node (check and modify the script if needed)
+> 2. After running the script, you must replace the `$HOME/.elys/config/priv_validator_key.json` with your cosmos's provider mainnet `priv_validator_key.json` file
+> 3. Only start the node after completing the key replacement to avoid double signing
+
+#### Option B: Manual Setup
+
 1. **Clone and Build**
 
 ```bash
@@ -62,6 +78,49 @@ c. Configure Node Settings
 
 - Add persistent peers and seeds in `config.toml`
 - Set minimum gas prices in `app.toml`:
+
+```
+minimum-gas-prices = "0.0003uelys,0.001ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349,0.001ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+```
+
+c. **For Governors**: Run those commands to register as a governor
+
+- Retrieve the governor pubkey:
+
+  ```
+  elysd cometbft show-validator
+  ```
+
+- Create the governor.json file:
+
+```bash
+cat <<EOF > /tmp/governor.json
+{
+	"pubkey": [PUBKEY],
+	"amount": "10000000uelys",
+	"moniker": "[MONIKER]",
+	"identity": "Elys Mainnet Governor",
+	"website": "https://elys.network",
+	"security": "team@elys.network",
+	"details": "validator's (optional) details",
+	"commission-rate": "0.1",
+	"commission-max-rate": "0.2",
+	"commission-max-change-rate": "0.01",
+	"min-self-delegation": "1"
+}
+EOF
+```
+
+- Create the governor:
+
+```bash
+elysd tx staking create-validator \
+    /tmp/governor.json \
+    --from [YOUR_KEY] \
+    --chain-id elys-1 \
+    --fees 20000uelys \
+    --gas auto
+```
 
 ### 3. Running the Node
 

--- a/mainnet/create_node.sh
+++ b/mainnet/create_node.sh
@@ -57,7 +57,6 @@ Environment="UNSAFE_SKIP_BACKUP=true"
 [Install]
 WantedBy=multi-user.target
 EOF
-
 fi
 
 # enable the elysd service

--- a/testnet/elysicstestnet-1/README.md
+++ b/testnet/elysicstestnet-1/README.md
@@ -91,10 +91,10 @@ c. **For Governors**: Run those commands to register as a governor
   elysd cometbft show-validator
   ```
 
-- Create the validator.json file:
+- Create the governor.json file:
 
 ```bash
-cat <<EOF > /tmp/validator.json
+cat <<EOF > /tmp/governor.json
 {
 	"pubkey": [PUBKEY],
 	"amount": "10000000uelys",
@@ -115,7 +115,7 @@ EOF
 
 ```bash
 elysd tx staking create-validator \
-    /tmp/validator.json \
+    /tmp/governor.json \
     --from [YOUR_KEY] \
     --chain-id elysicstestnet-1 \
     --fees 20000uelys \


### PR DESCRIPTION
- Added mainnet section to README.md with chain ID and setup instructions.
- Updated mainnet/create_node.sh to include service creation and checks for cosmovisor installation.
- Enhanced mainnet/README.md with quick setup script and important notes for validators.
- Modified testnet/create_node.sh to improve service setup and node initialization.
- Updated testnet/README.md to correct validator.json to governor.json in the governor registration process.