### PR TITLE
Added ibc transfer paths

### DIFF
--- a/_ibc/elys-axelar.json
+++ b/_ibc/elys-axelar.json
@@ -1,0 +1,38 @@
+{
+  "chain_1": {
+    "chain_name": "elys",
+    "client_id": "07-tendermint-4",
+    "connection_id": "connection-3"
+  },
+  "chain_2": {
+    "chain_name": "axelar",
+    "client_id": "07-tendermint-231",
+    "connection_id": "connection-222"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-3",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-163",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    }
+  ],
+  "operators": [
+    {
+      "discord": {
+        "id": "653208183325589529",
+        "handle": "hottochelli"
+      }
+    }
+  ]
+}

--- a/_ibc/elys-cosmos.json
+++ b/_ibc/elys-cosmos.json
@@ -1,0 +1,33 @@
+{
+  "chain_1": {
+    "chain_name": "elys",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-1"
+  },
+  "chain_2": {
+    "chain_name": "cosmoshub",
+    "client_id": "07-tendermint-1339",
+    "connection_id": "connection-1073"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-1",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-1266",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    }
+  ],
+  "operators": [
+
+  ]
+}

--- a/_ibc/elys-noble.json
+++ b/_ibc/elys-noble.json
@@ -1,0 +1,33 @@
+{
+  "chain_1": {
+    "chain_name": "elys",
+    "client_id": "07-tendermint-3",
+    "connection_id": "connection-2"
+  },
+  "chain_2": {
+    "chain_name": "noble",
+    "client_id": "07-tendermint-133",
+    "connection_id": "connection-130"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-2",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-117",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    }
+  ],
+  "operators": [
+
+  ]
+}


### PR DESCRIPTION
@avkr003 @cosmic-vagabond
In this PR we propose the structure how to keep the ibc paths for Elys network that will help us to monitor them and notify about issues over discord channel like the has in testnet, here: https://discord.com/channels/1049783263956324462/1267938422161539142

Also pay attention to the elys-axelar.json file, there we have additional array, "operators" which will serve to keep the discord information about operators who will have desire to operate the path and being notified in discord by monitoring system.
The screenshot as an example:
<img width="871" alt="Screenshot 2024-12-12 at 19 06 36" src="https://github.com/user-attachments/assets/44404926-0fd8-4218-93be-3c3e7b440024" />
